### PR TITLE
Adjusted obedience levels to fit current level curve.

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6491,11 +6491,7 @@ u8 GetAttackerObedienceForAction()
     if (FlagGet(FLAG_BADGE07_GET)) // Mind Badge
         obedienceLevel = 82;
 
-    if (B_OBEDIENCE_MECHANICS >= GEN_8
-     && !IsOtherTrainer(gBattleMons[gBattlerAttacker].otId, gBattleMons[gBattlerAttacker].otName))
-        levelReferenced = gBattleMons[gBattlerAttacker].metLevel;
-    else
-        levelReferenced = gBattleMons[gBattlerAttacker].level;
+    levelReferenced = gBattleMons[gBattlerAttacker].level;
 
     if (levelReferenced <= obedienceLevel)
         return OBEYS;

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -6474,22 +6474,22 @@ u8 GetAttackerObedienceForAction()
     if (FlagGet(FLAG_BADGE08_GET)) // Rain Badge, ignore obedience altogether
         return OBEYS;
 
-    obedienceLevel = 10;
+    obedienceLevel = 19;
 
     if (FlagGet(FLAG_BADGE01_GET)) // Stone Badge
-        obedienceLevel = 20;
+        obedienceLevel = 28;
     if (FlagGet(FLAG_BADGE02_GET)) // Knuckle Badge
-        obedienceLevel = 30;
+        obedienceLevel = 37;
     if (FlagGet(FLAG_BADGE03_GET)) // Dynamo Badge
-        obedienceLevel = 40;
+        obedienceLevel = 46;
     if (FlagGet(FLAG_BADGE04_GET)) // Heat Badge
-        obedienceLevel = 50;
+        obedienceLevel = 55;
     if (FlagGet(FLAG_BADGE05_GET)) // Balance Badge
-        obedienceLevel = 60;
+        obedienceLevel = 64;
     if (FlagGet(FLAG_BADGE06_GET)) // Feather Badge
-        obedienceLevel = 70;
+        obedienceLevel = 73;
     if (FlagGet(FLAG_BADGE07_GET)) // Mind Badge
-        obedienceLevel = 80;
+        obedienceLevel = 82;
 
     if (B_OBEDIENCE_MECHANICS >= GEN_8
      && !IsOtherTrainer(gBattleMons[gBattlerAttacker].otId, gBattleMons[gBattlerAttacker].otName))


### PR DESCRIPTION
Given the level curve is all the way up to level 100, when playtesting, I noticed that the mons don't properly respond commands past certain levels. This commit adjusts those levels to allow for proper mon obedience while their levels are below the level caps.

When integrating, **PLEASE REBASE**!!!