### PR TITLE
Overhauled type balls.

### DIFF
--- a/data/maps/OldaleTown_Mart/scripts.inc
+++ b/data/maps/OldaleTown_Mart/scripts.inc
@@ -29,6 +29,8 @@ OldaleTown_Mart_ExpandedItems::
 	.align 2
 OldaleTown_Mart_Pokemart_Expanded:
 	.2byte ITEM_POKE_BALL
+	.2byte ITEM_NET_BALL
+	.2byte ITEM_NEST_BALL
 	.2byte ITEM_POTION
 	.2byte ITEM_ANTIDOTE
 	.2byte ITEM_PARALYZE_HEAL

--- a/data/maps/PetalburgCity_Mart/scripts.inc
+++ b/data/maps/PetalburgCity_Mart/scripts.inc
@@ -15,6 +15,8 @@ PetalburgCity_Mart_EventScript_Clerk::
 	.align 2
 PetalburgCity_Mart_Pokemart_Basic:
 	.2byte ITEM_POKE_BALL
+	.2byte ITEM_FAST_BALL
+	.2byte ITEM_MOON_BALL
 	.2byte ITEM_POTION
 	.2byte ITEM_ANTIDOTE
 	.2byte ITEM_PARALYZE_HEAL
@@ -37,6 +39,8 @@ PetalburgCity_Mart_EventScript_ExpandedItems::
 PetalburgCity_Mart_Pokemart_Expanded:
 	.2byte ITEM_POKE_BALL
 	.2byte ITEM_GREAT_BALL
+	.2byte ITEM_FAST_BALL
+	.2byte ITEM_MOON_BALL
 	.2byte ITEM_POTION
 	.2byte ITEM_SUPER_POTION
 	.2byte ITEM_ANTIDOTE

--- a/data/maps/RustboroCity_Mart/scripts.inc
+++ b/data/maps/RustboroCity_Mart/scripts.inc
@@ -19,6 +19,8 @@ RustboroCity_Mart_EventScript_PokemartBasic::
 	.align 2
 RustboroCity_Mart_Pokemart_Basic:
 	.2byte ITEM_POKE_BALL
+	.2byte ITEM_HEAVY_BALL
+	.2byte ITEM_REPEAT_BALL
 	.2byte ITEM_POTION
 	.2byte ITEM_SUPER_POTION
 	.2byte ITEM_ANTIDOTE
@@ -40,6 +42,7 @@ RustboroCity_Mart_EventScript_PokemartExpanded::
 RustboroCity_Mart_Pokemart_Expanded:
 	.2byte ITEM_POKE_BALL
 	.2byte ITEM_TIMER_BALL
+	.2byte ITEM_HEAVY_BALL
 	.2byte ITEM_REPEAT_BALL
 	.2byte ITEM_POTION
 	.2byte ITEM_SUPER_POTION

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -8344,7 +8344,7 @@ static void Cmd_yesnoboxlearnmove(void)
                 ShowSelectMovePokemonSummaryScreen_BW(gPlayerParty, gBattleStruct->expGetterMonId, gPlayerPartyCount - 1, ReshowBattleScreenAfterMenu, gMoveToLearn);
             else
                 ShowSelectMovePokemonSummaryScreen(gPlayerParty, gBattleStruct->expGetterMonId, gPlayerPartyCount - 1, ReshowBattleScreenAfterMenu, gMoveToLearn);
-            
+
             gBattleScripting.learnMoveState++;
         }
         break;
@@ -13610,38 +13610,40 @@ static void Cmd_handleballthrow(void)
                     ballMultiplier = 200;
                 break;
             case BALL_NET:
-                if (IS_BATTLER_ANY_TYPE(gBattlerTarget, TYPE_WATER, TYPE_BUG))
-                    ballMultiplier = B_NET_BALL_MODIFIER >= GEN_7 ? 350 : 300;
+                if (IS_BATTLER_ANY_TYPE(gBattlerTarget, TYPE_FLYING, TYPE_BUG))
+                    ballMultiplier = 250;
                 break;
             case BALL_DIVE:
-                if (GetCurrentMapType() == MAP_TYPE_UNDERWATER
-                    || (B_DIVE_BALL_MODIFIER >= GEN_4 && (gIsFishingEncounter || gIsSurfingEncounter)))
-                    ballMultiplier = 350;
+                if (IS_BATTLER_ANY_TYPE(gBattlerTarget, TYPE_WATER, TYPE_ICE))
+                    ballMultiplier = 250;
+                break;
+            case BALL_MOON:
+                if (IS_BATTLER_ANY_TYPE(gBattlerTarget, TYPE_DARK, TYPE_GHOST))
+                    ballMultiplier = 250;
+                break;
+            case BALL_FAST:
+                if (IS_BATTLER_ANY_TYPE(gBattlerTarget, TYPE_NORMAL, TYPE_ELECTRIC))
+                    ballMultiplier = 250;
+                break;
+            case BALL_HEAVY:
+                if (IS_BATTLER_ANY_TYPE(gBattlerTarget, TYPE_STEEL, TYPE_FIGHTING))
+                    ballMultiplier = 250;
                 break;
             case BALL_NEST:
-                if (B_NEST_BALL_MODIFIER >= GEN_6)
-                {
-                    //((41 - Pokémon's level) ÷ 10)× if Pokémon's level is between 1 and 29, 1× otherwise.
-                    if (gBattleMons[gBattlerTarget].level < 30)
-                        ballMultiplier = 410 - (gBattleMons[gBattlerTarget].level * 10);
-                }
-                else if (B_NEST_BALL_MODIFIER >= GEN_5)
-                {
-                    //((41 - Pokémon's level) ÷ 10)×, minimum 1×
-                    if (gBattleMons[gBattlerTarget].level < 31)
-                        ballMultiplier = 410 - (gBattleMons[gBattlerTarget].level * 10);
-                }
-                else if (gBattleMons[gBattlerTarget].level < 40)
-                {
-                    //((40 - Pokémon's level) ÷ 10)×, minimum 1×
-                    ballMultiplier = 400 - (gBattleMons[gBattlerTarget].level * 10);
-                    if (ballMultiplier <= 90)
-                        ballMultiplier = 100;
-                }
+                if (IS_BATTLER_ANY_TYPE(gBattlerTarget, TYPE_GROUND, TYPE_GRASS))
+                    ballMultiplier = 250;
                 break;
             case BALL_REPEAT:
-                if (GetSetPokedexFlag(SpeciesToNationalPokedexNum(gBattleMons[gBattlerTarget].species), FLAG_GET_CAUGHT))
-                    ballMultiplier = (B_REPEAT_BALL_MODIFIER >= GEN_7 ? 350 : 300);
+                if (IS_BATTLER_ANY_TYPE(gBattlerTarget, TYPE_FIRE, TYPE_ROCK))
+                    ballMultiplier = 250;
+                break;
+            case BALL_LURE:
+                if (IS_BATTLER_ANY_TYPE(gBattlerTarget, TYPE_DRAGON, TYPE_POISON))
+                    ballMultiplier = 250;
+                break;
+            case BALL_LOVE:
+                if (IS_BATTLER_ANY_TYPE(gBattlerTarget, TYPE_PSYCHIC, TYPE_FAIRY))
+                    ballMultiplier = 250;
                 break;
             case BALL_TIMER:
                 ballMultiplier = 100 + (gBattleResults.battleTurnCounter * (B_TIMER_BALL_MODIFIER >= GEN_5 ? 30 : 10));
@@ -13664,82 +13666,6 @@ static void Cmd_handleballthrow(void)
                     ballMultiplier = 400;
                 else if (gBattleMons[gBattlerAttacker].level > gBattleMons[gBattlerTarget].level)
                     ballMultiplier = 200;
-                break;
-            case BALL_LURE:
-                if (gIsFishingEncounter)
-                {
-                    if (B_LURE_BALL_MODIFIER >= GEN_8)
-                        ballMultiplier = 400;
-                    else if (B_LURE_BALL_MODIFIER >= GEN_7)
-                        ballMultiplier = 500;
-                    else
-                        ballMultiplier = 300;
-                }
-                break;
-            case BALL_MOON:
-            {
-                const struct Evolution *evolutions = GetSpeciesEvolutions(gBattleMons[gBattlerTarget].species);
-                if (evolutions == NULL)
-                    break;
-                for (i = 0; evolutions[i].method != EVOLUTIONS_END; i++)
-                {
-                    if (evolutions[i].method == EVO_ITEM
-                        && evolutions[i].param == ITEM_MOON_STONE)
-                        ballMultiplier = 400;
-                }
-            }
-            break;
-            case BALL_LOVE:
-                if (gBattleMons[gBattlerTarget].species == gBattleMons[gBattlerAttacker].species)
-                {
-                    u8 gender1 = GetMonGender(GetBattlerMon(gBattlerTarget));
-                    u8 gender2 = GetMonGender(GetBattlerMon(gBattlerAttacker));
-
-                    if (gender1 != gender2 && gender1 != MON_GENDERLESS && gender2 != MON_GENDERLESS)
-                        ballMultiplier = 800;
-                }
-                break;
-            case BALL_FAST:
-                if (GetSpeciesBaseSpeed(gBattleMons[gBattlerTarget].species) >= 100)
-                    ballMultiplier = 400;
-                break;
-            case BALL_HEAVY:
-                i = GetSpeciesWeight(gBattleMons[gBattlerTarget].species);
-                if (B_HEAVY_BALL_MODIFIER >= GEN_7)
-                {
-                    if (i < 1000)
-                        ballAddition = -20;
-                    else if (i < 2000)
-                        ballAddition = 0;
-                    else if (i < 3000)
-                        ballAddition = 20;
-                    else
-                        ballAddition = 30;
-                }
-                else if (B_HEAVY_BALL_MODIFIER >= GEN_4)
-                {
-                    if (i < 2048)
-                        ballAddition = -20;
-                    else if (i < 3072)
-                        ballAddition = 20;
-                    else if (i < 4096)
-                        ballAddition = 30;
-                    else
-                        ballAddition = 40;
-                }
-                else
-                {
-                    if (i < 1024)
-                        ballAddition = -20;
-                    else if (i < 2048)
-                        ballAddition = 0;
-                    else if (i < 3072)
-                        ballAddition = 20;
-                    else if (i < 4096)
-                        ballAddition = 30;
-                    else
-                        ballAddition = 40;
-                }
                 break;
             case BALL_DREAM:
                 if (B_DREAM_BALL_MODIFIER >= GEN_8 && (gBattleMons[gBattlerTarget].status1 & STATUS1_SLEEP || GetBattlerAbility(gBattlerTarget) == ABILITY_COMATOSE))

--- a/src/data/items.h
+++ b/src/data/items.h
@@ -278,7 +278,7 @@ const struct Item gItemsInfo[] =
         .price = 50,
         .description = COMPOUND_STRING(
             "A Ball that works\n"
-            "well on Water- and\n"
+            "well on Flying- and\n"
             "Bug-type Pokémon."),
         .pocket = POCKET_POKE_BALLS,
         .type = ITEM_USE_BAG_MENU,
@@ -290,12 +290,12 @@ const struct Item gItemsInfo[] =
 
     [ITEM_NEST_BALL] =
     {
-        .name = ITEM_NAME("Nest Ball"),
+        .name = ITEM_NAME("Soil Ball"),
         .price = 50,
         .description = COMPOUND_STRING(
             "A Ball that works\n"
-            "better on weaker\n"
-            "Pokémon."),
+            "well on Ground- and\n"
+            "Grass-type PKMN."),
         .pocket = POCKET_POKE_BALLS,
         .type = ITEM_USE_BAG_MENU,
         .battleUsage = EFFECT_ITEM_THROW_BALL,
@@ -310,8 +310,8 @@ const struct Item gItemsInfo[] =
         .price = 50,
         .description = COMPOUND_STRING(
             "A Ball that works\n"
-            "better on Pokémon\n"
-            "on the ocean floor."),
+            "well on Water- and\n"
+            "Ice-type PKMN."),
         .pocket = POCKET_POKE_BALLS,
         .type = ITEM_USE_BAG_MENU,
         .battleUsage = EFFECT_ITEM_THROW_BALL,
@@ -370,12 +370,12 @@ const struct Item gItemsInfo[] =
 
     [ITEM_REPEAT_BALL] =
     {
-        .name = ITEM_NAME("Repeat Ball"),
+        .name = ITEM_NAME("Scorched Ball"),
         .price = 50,
         .description = COMPOUND_STRING(
             "A Ball that works\n"
-            "better on Pokémon\n"
-            "caught before."),
+            "well on Fire- and\n"
+            "Rock-type PKMN."),
         .pocket = POCKET_POKE_BALLS,
         .type = ITEM_USE_BAG_MENU,
         .battleUsage = EFFECT_ITEM_THROW_BALL,
@@ -418,12 +418,12 @@ const struct Item gItemsInfo[] =
 
     [ITEM_LURE_BALL] =
     {
-        .name = ITEM_NAME("Lure Ball"),
+        .name = ITEM_NAME("Suppr. Ball"),
         .price = 50,
         .description = COMPOUND_STRING(
             "A Ball that works\n"
-            "well on fished\n"
-            "up Pokémon."),
+            "well on Dragon- and\n"
+            "Poison-type PKMN."),
         .pocket = POCKET_POKE_BALLS,
         .type = ITEM_USE_BAG_MENU,
         .battleUsage = EFFECT_ITEM_THROW_BALL,
@@ -438,8 +438,8 @@ const struct Item gItemsInfo[] =
         .price = 50,
         .description = COMPOUND_STRING(
             "A Ball that works\n"
-            "well on Moon\n"
-            "Stone users."),
+            "well on Dark- and\n"
+            "Ghost-type PKMN."),
         .pocket = POCKET_POKE_BALLS,
         .type = ITEM_USE_BAG_MENU,
         .battleUsage = EFFECT_ITEM_THROW_BALL,
@@ -466,12 +466,12 @@ const struct Item gItemsInfo[] =
 
     [ITEM_LOVE_BALL] =
     {
-        .name = ITEM_NAME("Love Ball"),
+        .name = ITEM_NAME("Ethereal Ball"),
         .price = 50,
         .description = COMPOUND_STRING(
-            "Works well on\n"
-            "Pokémon of the\n"
-            "opposite gender."),
+            "A Ball that works\n"
+            "well on Psychic- and\n"
+            "Fairy-type PKMN."),
         .pocket = POCKET_POKE_BALLS,
         .type = ITEM_USE_BAG_MENU,
         .battleUsage = EFFECT_ITEM_THROW_BALL,
@@ -485,9 +485,9 @@ const struct Item gItemsInfo[] =
         .name = ITEM_NAME("Fast Ball"),
         .price = 50,
         .description = COMPOUND_STRING(
-            "Works well on\n"
-            "very fast\n"
-            "Pokémon."),
+            "A Ball that works\n"
+            "well on Normal- and\n"
+            "Electric-type PKMN."),
         .pocket = POCKET_POKE_BALLS,
         .type = ITEM_USE_BAG_MENU,
         .battleUsage = EFFECT_ITEM_THROW_BALL,
@@ -501,9 +501,9 @@ const struct Item gItemsInfo[] =
         .name = ITEM_NAME("Heavy Ball"),
         .price = 50,
         .description = COMPOUND_STRING(
-            "Works well on\n"
-            "very heavy\n"
-            "Pokémon."),
+            "A Ball that works\n"
+            "well on Steel- and\n"
+            "Fighting-type PKMN."),
         .pocket = POCKET_POKE_BALLS,
         .type = ITEM_USE_BAG_MENU,
         .battleUsage = EFFECT_ITEM_THROW_BALL,


### PR DESCRIPTION
This pull request updates several Poké Ball items to have new names, updated descriptions, and new in-battle effects based on Pokémon types, rather than their original mechanics. It also updates the Poké Mart inventories in several towns to offer these balls.

**Poké Ball Item Overhauls**

* Updated the names and descriptions of several Poké Balls to reflect their new type-based effects, e.g. `Nest Ball` is now `Soil Ball`, `Repeat Ball` is now `Scorched Ball`, and others, with descriptions now specifying which types they are effective against. [[1]](diffhunk://#diff-803ecfa478a79962e8ad1b380e6d0eaf0bdbe799757a101ac720dff06637a2e8L293-R298) [[2]](diffhunk://#diff-803ecfa478a79962e8ad1b380e6d0eaf0bdbe799757a101ac720dff06637a2e8L373-R378) [[3]](diffhunk://#diff-803ecfa478a79962e8ad1b380e6d0eaf0bdbe799757a101ac720dff06637a2e8L421-R426) [[4]](diffhunk://#diff-803ecfa478a79962e8ad1b380e6d0eaf0bdbe799757a101ac720dff06637a2e8L441-R442) [[5]](diffhunk://#diff-803ecfa478a79962e8ad1b380e6d0eaf0bdbe799757a101ac720dff06637a2e8L469-R474) [[6]](diffhunk://#diff-803ecfa478a79962e8ad1b380e6d0eaf0bdbe799757a101ac720dff06637a2e8L488-R490) [[7]](diffhunk://#diff-803ecfa478a79962e8ad1b380e6d0eaf0bdbe799757a101ac720dff06637a2e8L504-R506) [[8]](diffhunk://#diff-803ecfa478a79962e8ad1b380e6d0eaf0bdbe799757a101ac720dff06637a2e8L281-R281) [[9]](diffhunk://#diff-803ecfa478a79962e8ad1b380e6d0eaf0bdbe799757a101ac720dff06637a2e8L313-R314)

* Changed the in-battle effects of these balls in `Cmd_handleballthrow` to apply a catch rate multiplier when used against Pokémon of specific types, replacing the previous mechanics (e.g., speed, weight, gender, etc.). [[1]](diffhunk://#diff-362cff5da832aff8867c153dcde88ca149916d70f4e67aa92ea37ceb320bc459L13613-R13646) [[2]](diffhunk://#diff-362cff5da832aff8867c153dcde88ca149916d70f4e67aa92ea37ceb320bc459L13668-L13743)

**Poké Mart Inventory Updates**

* Added the new or renamed balls to the Poké Marts in Oldale Town, Petalburg City, and Rustboro City, expanding the selection available to the player. [[1]](diffhunk://#diff-dcb3bcb30cd3d6b48669fbc6157ecf594184663f72693bcfd54bfe75ae037f4eR32-R33) [[2]](diffhunk://#diff-d04b384e0e550bfab5b7503696886eccb946f1b77e4f74f909e7e751192e45feR18-R19) [[3]](diffhunk://#diff-d04b384e0e550bfab5b7503696886eccb946f1b77e4f74f909e7e751192e45feR42-R43) [[4]](diffhunk://#diff-496fa0a3f6183f52c02b76df7d1c23a87070997d36d98b40735d523ba1a872ddR22-R23) [[5]](diffhunk://#diff-496fa0a3f6183f52c02b76df7d1c23a87070997d36d98b40735d523ba1a872ddR45)

These changes collectively rework how specialty Poké Balls function and are obtained, making their effects more straightforward and type-based.